### PR TITLE
Implement hw 2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Locals
+*cmake-*-build*
+*cmake-build*
+build/
+.vscode/
+.cache/
+.vs/
+CMakeSettings.json
+
 # Prerequisites
 *.d
 
@@ -30,3 +39,5 @@
 *.exe
 *.out
 *.app
+
+build-dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(Semester2
+    VERSION
+        1.0
+    LANGUAGES
+        CXX
+)
+
+option(HOMEWORK_1 OFF)
+option(HOMEWORK_2 OFF)
+
+if (HOMEWORK_1)
+    add_subdirectory(homework-1)
+elseif(HOMEWORK_2)
+    add_subdirectory(homework-2)
+endif(HOMEWORK_1)

--- a/homework-2/static_array.cpp
+++ b/homework-2/static_array.cpp
@@ -2,5 +2,192 @@
 // Created by Denis on 12.03.2021.
 //
 
+#ifndef STATIC_ARRAY_CPP
+#define STATIC_ARRAY_CPP
+
 #include "static_array.h"
 
+#include <stdexcept>
+
+namespace detail {
+
+template <typename T>
+inline T& GetByIndex(uint8_t* memory, size_t index) {
+  return *reinterpret_cast<T*>(memory + sizeof(T) * index);
+}
+
+template <typename T>
+inline void CreateAtIndex(uint8_t* memory, size_t index, T&& object) {
+  void* pointer = memory + sizeof(T) * index;
+  new (pointer) T(std::forward<T>(object));
+}
+
+template <typename T, typename... Args>
+inline void CreateAtIndex(uint8_t* memory, size_t index, Args&&... args) {
+  void* pointer = memory + sizeof(T) * index;
+  new (pointer) T(std::forward<Args>(args)...);
+}
+
+}  // namespace detail
+template <typename T, size_t capacity>
+inline size_t static_array<T, capacity>::current_size() const {
+  return m_size;
+}
+
+template <typename T, size_t capacity>
+inline size_t static_array<T, capacity>::size() const {
+  return m_capacity;
+}
+
+template <typename T, size_t capacity>
+inline void static_array<T, capacity>::clear() {
+  for (size_t i = 0; i < m_size; ++i) {
+    if (m_has_value[i]) {
+      detail::GetByIndex<T>(m_data, i).~T();
+    }
+  }
+  std::fill(m_has_value.begin(), m_has_value.end(), false);
+  m_size = 0;
+}
+
+template <typename T, size_t capacity>
+template <typename... Args>
+inline typename static_array<T, capacity>::iterator
+static_array<T, capacity>::emplace(size_t index, Args&&... args) {
+  if (m_has_value[index]) {
+    detail::GetByIndex<T>(m_data, index).~T();
+  } else {
+    m_size++;
+    m_has_value[index] = true;
+  }
+  detail::CreateAtIndex<T>(m_data, index, std::forward<Args>(args)...);
+  return iterator(this, index);
+}
+
+template <typename T, size_t capacity>
+inline typename static_array<T, capacity>::iterator
+static_array<T, capacity>::emplace(size_t index, T&& element) {
+  if (m_has_value[index]) {
+    detail::GetByIndex<T>(m_data, index).~T();
+  } else {
+    m_size++;
+    m_has_value[index] = true;
+  }
+  detail::CreateAtIndex<T>(m_data, index, std::forward<T>(element));
+  return iterator(this, index);
+}
+
+template <typename T, size_t capacity>
+inline T& static_array<T, capacity>::at(size_t index) {
+  if (index >= m_capacity) {
+    throw std::out_of_range("Index is too large");
+  }
+  if (!m_has_value[index]) {
+    throw std::runtime_error("Value is unset");
+  }
+  return detail::GetByIndex<T>(m_data, index);
+}
+
+template <typename T, size_t capacity>
+inline static_array<T, capacity>::iterator::iterator(const iterator& other)
+    : m_container(other.m_container), m_index(other.m_index) {}
+
+template <typename T, size_t capacity>
+inline static_array<T, capacity>::iterator::~iterator() = default;
+
+template <typename T, size_t capacity>
+inline typename static_array<T, capacity>::iterator&
+static_array<T, capacity>::iterator::operator=(const iterator& other) {
+  m_container = other.m_container;
+  m_index = other.m_index;
+}
+
+template <typename T, size_t capacity>
+inline typename static_array<T, capacity>::iterator&
+static_array<T, capacity>::iterator::operator++() {
+  m_index = iterator::GetNextInitialized(m_container, m_index + 1);
+  return *this;
+}
+
+template <typename T, size_t capacity>
+inline typename static_array<T, capacity>::iterator&
+static_array<T, capacity>::iterator::operator--() {
+  m_index = GetPreviousInitialized(m_container, m_index - 1);
+  return *this;
+}
+
+template <typename T, size_t capacity>
+inline T* static_array<T, capacity>::iterator::operator->() const {
+  return &detail::GetByIndex<T>(m_container->m_data, m_index);
+}
+
+template <typename T, size_t capacity>
+inline T& static_array<T, capacity>::iterator::operator*() const {
+  return detail::GetByIndex<T>(m_container->m_data, m_index);
+}
+
+template <typename T, size_t capacity>
+inline static_array<T, capacity>::iterator::iterator(
+    static_array<T, capacity>* container, size_t index)
+    : m_container(container), m_index(index) {}
+
+template <typename T, size_t capacity>
+inline void static_array<T, capacity>::erase(static_array::iterator iterator) {
+  m_has_value[iterator.m_index] = false;
+  detail::GetByIndex<T>(m_data, iterator.m_index).~T();
+  m_size--;
+}
+
+template <typename T, size_t capacity>
+inline typename static_array<T, capacity>::iterator
+static_array<T, capacity>::begin() {
+  return iterator(this, iterator::GetNextInitialized(this, 0));
+}
+
+template <typename T, size_t capacity>
+inline typename static_array<T, capacity>::iterator
+static_array<T, capacity>::end() {
+  return iterator(this, m_capacity);
+}
+
+template <typename T, size_t capacity>
+inline bool static_array<T, capacity>::iterator::operator==(const typename static_array<T, capacity>::iterator& other) const {
+  return m_container == other.m_container && m_index == other.m_index;
+}
+
+template <typename T, size_t capacity>
+inline bool static_array<T, capacity>::iterator::operator!=(typename static_array<T, capacity>::iterator const& other) const {
+  return !(*this == other);
+}
+
+template <typename T, size_t capacity>
+inline size_t static_array<T, capacity>::iterator::GetNextInitialized(
+    const static_array<T, capacity>* container,
+    size_t starting_index) {
+  for (size_t pos = starting_index; pos < container->m_capacity; ++pos) {
+    if (container->m_has_value[pos]) {
+      return pos;
+    }
+  }
+  return container->m_capacity;
+}
+
+template <typename T, size_t capacity>
+inline size_t static_array<T, capacity>::iterator::GetPreviousInitialized(
+    const static_array<T, capacity>* container,
+    size_t starting_index) {
+  for (size_t pos = starting_index; pos < std::numeric_limits<size_t>::max(); --pos) {
+    if (container->m_has_value[pos]) {
+      return pos;
+    }
+  }
+  return container->m_capacity;
+}
+
+template <typename T, size_t capacity>
+inline static_array<T, capacity>::~static_array() {
+  clear();
+  delete[] m_data;
+}
+
+#endif  // STATIC_ARRAY_CPP

--- a/homework-2/static_array.h
+++ b/homework-2/static_array.h
@@ -2,55 +2,100 @@
 // Created by Denis on 12.03.2021.
 //
 
-#ifndef HOMEWORK_2_STATIC_ARRAY_H
-#define HOMEWORK_2_STATIC_ARRAY_H
+#pragma once
 
-template<typename T, size_t sz = 0>
+#ifndef STATIC_ARRAY_H
+#define STATIC_ARRAY_H
+
+#include <algorithm>
+#include <bitset>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+template<typename T, size_t capacity = 0>
 class static_array {
-public:
-    class iterator {
-    public:
-        iterator(const iterator &);
+  friend class iterator;
+ public:
+  class iterator {
+    friend static_array<T, capacity>;
 
-        ~iterator();
+   public:
+    iterator(const iterator &);
 
-        iterator &operator=(const iterator &);
+    ~iterator();
 
-        iterator &operator++();
+    iterator &operator=(const iterator &);
 
-        iterator &operator--();
+    iterator &operator++();
 
-        T *operator->() const;
+    iterator &operator--();
 
-        T &operator*() const;
+    T *operator->() const;
 
-        friend bool operator==(const iterator &, const iterator &);
+    T &operator*() const;
 
-        friend bool operator!=(const iterator &, const iterator &);
-    };
+    bool operator==(iterator const &other) const;
+    
+    bool operator!=(iterator const& other) const;
 
-    static_array();
+   private:
+    iterator(static_array<T, capacity>* container, size_t index);
 
-    static_array(size_t sz);
+    static size_t GetNextInitialized(const static_array<T, capacity>* container, size_t starting_index);
+    static size_t GetPreviousInitialized(const static_array<T, capacity>* container, size_t starting_index);
+    
+   private:
+    static_array<T, capacity> *m_container;
+    size_t m_index;
+  };
 
-    size_t current_size();
+  template <size_t cur_capacity = capacity,
+            typename std::enable_if<(cur_capacity == 0), int>::type = 0>
+  static_array(size_t size)
+      : m_data(new uint8_t[size * sizeof(T)]),
+        m_has_value(size),
+        m_capacity(size),
+        m_size(0) {}
 
-    size_t size();
+  template <size_t cur_capacity = capacity,
+            typename std::enable_if<(cur_capacity > 0), int>::type = 0>
+  static_array()
+      : m_data(new uint8_t[capacity * sizeof(T)]),
+        m_has_value(capacity),
+        m_capacity(capacity),
+        m_size(0) {}
 
-    void clear();
+  size_t current_size() const;
 
-    static_array::iterator emplace(size_t ind, T &&obj);
+  size_t size() const;
 
-    template<class... Args>
-    static_array::iterator emplace(size_t ind, Args &&... args);
+  void clear();
 
-    void erase(static_array::iterator);
+  template <typename... Args>
+  static_array::iterator emplace(size_t index, Args&&... args);
 
-    T &at(size_t ind);
+  static_array::iterator emplace(size_t index, T&& element);
+  
+  void erase(static_array::iterator iterator);
 
-    static_array::iterator begin();
+  T &at(size_t index);
 
-    static_array::iterator end();
+  static_array::iterator begin();
+
+  static_array::iterator end();
+
+  ~static_array();
+  
+ private:
+  uint8_t* m_data;
+  std::vector<bool> m_has_value;
+  size_t m_capacity;
+  size_t m_size;
 };
 
-#endif //HOMEWORK_2_STATIC_ARRAY_H
+#include "static_array.cpp"
+
+#endif

--- a/homework-2/tests.cpp
+++ b/homework-2/tests.cpp
@@ -83,7 +83,7 @@ TEST(static_array, iterator) {
     static_array<int, 10>::iterator it1 = st.emplace(1, 13);
     auto it2 = st.emplace(4, 199);
     st.erase(it2);
-    EXPECT_EQ(st.size(), 1);
+    EXPECT_EQ(st.current_size(), 1);
     EXPECT_EQ(*it1, 13);
 }
 

--- a/homework-2/tests.cpp
+++ b/homework-2/tests.cpp
@@ -17,7 +17,7 @@ public:
 
     A(A &&obj) {};
 
-    A &operator=(A &&obj) {};
+    A &operator=(A &&obj) = default;
 
     A(std::vector<int> &&vec, int &&a, std::array<int, 5> &&b) {}
 };

--- a/homework-2/tests.cpp
+++ b/homework-2/tests.cpp
@@ -104,8 +104,8 @@ TEST(static_array, iteratorsfunc) {
         st.emplace(i, B(i * 3));
     auto it = st.end();
     for (int i = 9; i >= 0; i -= 3) {
-        EXPECT_EQ(it->getNum(), i * 3);
         --it;
+        EXPECT_EQ(it->getNum(), i * 3);
     }
 }
 


### PR DESCRIPTION
Ready

I could not find a way to move constructors into separate file.

I wanted to keep constructors ```static_array<int, 10> st;``` and  ```static_array<int> st(10);``` mutual exclusive. i.e. disable  ```static_array<int, 10> st(15);``` and ```static_array<int> st();```